### PR TITLE
fix: error_info write twice

### DIFF
--- a/dingo/exec/local.py
+++ b/dingo/exec/local.py
@@ -83,7 +83,7 @@ class LocalExecutor(ExecProto):
             self.summary = self.summarize(self.summary)
             self.summary.finish_time = time.strftime('%Y%m%d_%H%M%S', time.localtime())
             if self.input_args.save_data:
-                self.save_data(output_path, self.input_args, self.bad_info_list, self.good_info_list, self.summary)
+                self.save_data(output_path, self.input_args, self.bad_info_list[self.bad_info_index:], self.good_info_list[self.good_info_index:], self.summary)
 
         return [self.summary]
 


### PR DESCRIPTION
数据规模较大时定量保存数据，但是最后一次保存数据不应重复写入之前已经保存过的数据