### PR TITLE
feat: support spark llm check.

### DIFF
--- a/dingo/exec/spark.py
+++ b/dingo/exec/spark.py
@@ -111,7 +111,7 @@ class SparkExecutor(ExecProto):
                 task_id=str(uuid.uuid1()),
                 task_name=self.input_args.task_name,
                 eval_group=self.input_args.eval_group,
-                input_path=self.input_args.input_path,
+                input_path=self.input_args.input_path if not self.spark_rdd else '',
                 output_path='',
                 create_time=create_time,
                 score=0,
@@ -138,6 +138,7 @@ class SparkExecutor(ExecProto):
         return [self.summary]
 
     def evaluate(self, data_rdd_item) -> Dict[str, Any]:
+        Model.apply_config_for_spark_driver(self.input_args.custom_config, self.input_args.eval_group)
         # eval with models ( Big Data Caution ）
         data: MetaData = data_rdd_item
         result_info = ResultInfo(data_id=data.data_id, prompt=data.prompt, content=data.content)


### PR DESCRIPTION
The current project does not support llm check on Spark yet. If run, it will report an error and show that the model is not configured. This is because on the Spark platform, the configuration of the worker side is not sent to the driver side. 

Test Case:
```
from pyspark import SparkConf

from dingo.model.model import Model
from dingo.io import InputArgs
from dingo.exec import Executor

input_data = {
    "eval_group": "test123456",
    "save_data": True,
    "custom_config":
    {
        "prompt_list": ["PromptTextQualityV3"],
        "llm_config":
            {
                "detect_text_quality_detail":
                    {
                        "key": "xxxxxxxxxxx",
                        "api_url": "yyyyyyyyyyyyyy",
                    }
            }
    }
}
input_args = InputArgs(**input_data)
executor = Executor.exec_map["spark"](input_args, spark_session=spark, spark_rdd=input_rdd_format)
result = executor.execute()
result = result[0].to_dict()
print(result)
```
Test Result:
```
{'task_id': '6f9d2292-d932-11ef-9689-80615f168bdd', 'task_name': 'dingo', 'eval_group': 'test123567', 'input_path': '', 'output_path': '', 'create_time': '20250123_102528', 'finish_time': '20250123_103334', 'score': 41.6, 'num_good': 208, 'num_bad': 292, 'total': 500, 'type_ratio': {'Completeness': 0.308, 'Effectiveness': 0.106, 'Security': 0.07, 'Similarity': 0.1}, 'name_ratio': {'Completeness-Error_Formula_Table': 0.002, 'Completeness-Error_List_Number': 0.004, 'Completeness-Error_Section_Order': 0.302, 'Effectiveness-Error_Garbled_Characters': 0.014, 'Effectiveness-Error_Lack_Punctuation': 0.07, 'Effectiveness-Error_Words_Stuck': 0.022, 'Security-Error_Political_Content': 0.036, 'Security-Error_Prohibited_Content': 0.034, 'Similarity-Error_Duplicate_Content': 0.1}}
```
