### PR TITLE
feat: add llm demo, including local and remote.（deepseek support）

### DIFF
--- a/dingo/model/llm/base_openai.py
+++ b/dingo/model/llm/base_openai.py
@@ -41,10 +41,10 @@ class BaseOpenAI(BaseLLM):
 
     @classmethod
     def send_messages(cls, messages: List):
-        if cls.dynamic_config.model is None:
-            model_name = cls.client.models.list().data[0].id
-        else:
+        if cls.dynamic_config.model:
             model_name = cls.dynamic_config.model
+        else:
+            model_name = cls.client.models.list().data[0].id
 
         params = cls.dynamic_config.parameters
         cls.validate_config(params)

--- a/examples/app_huggingface/app.py
+++ b/examples/app_huggingface/app.py
@@ -5,7 +5,7 @@ from dingo.exec import Executor
 from dingo.io import InputArgs
 
 
-def dingo_demo(input_path, data_format, column_content, rule_list, prompt_list, key, api_url):
+def dingo_demo(input_path, data_format, column_content, rule_list, prompt_list, model, key, api_url):
     if not input_path:
         return 'ValueError: input_path can not be empty, please input.'
     if not data_format:
@@ -27,6 +27,7 @@ def dingo_demo(input_path, data_format, column_content, rule_list, prompt_list, 
                     {
                         "detect_text_quality_detail":
                             {
+                                "model": model,
                                 "key": key,
                                 "api_url": api_url,
                             }
@@ -55,8 +56,9 @@ if __name__ == '__main__':
                 column_content = gr.Textbox(value="content", placeholder="please input column name of content in dataset", label="column_content")
                 rule_list = gr.CheckboxGroup(choices=rule_options, label="rule_list")
                 prompt_list = gr.CheckboxGroup(choices=prompt_options, label="prompt_list")
-                key = gr.Textbox(placeholder="If want to use llm, please input the key of it.", label="key")
-                api_url = gr.Textbox(placeholder="If want to use llm, please input the api_url of it.", label="api_url")
+                model = gr.Textbox(placeholder="If want to use llm, please input model, such as: deepseek-chat", label="model")
+                key = gr.Textbox(placeholder="If want to use llm, please input key, such as: 123456789012345678901234567890xx", label="key")
+                api_url = gr.Textbox(placeholder="If want to use llm, please input api_url, such as: https://api.deepseek.com/v1", label="api_url")
                 with gr.Row():
                     submit_single = gr.Button(value="Submit", interactive=True, variant="primary")
             with gr.Column():
@@ -65,7 +67,7 @@ if __name__ == '__main__':
 
         submit_single.click(
             fn=dingo_demo,
-            inputs=[input_path, data_format, column_content, rule_list, prompt_list, key, api_url],
+            inputs=[input_path, data_format, column_content, rule_list, prompt_list, model, key, api_url],
             outputs=output
         )
 

--- a/examples/llm/local_llm.py
+++ b/examples/llm/local_llm.py
@@ -1,0 +1,28 @@
+from dingo.exec import Executor
+from dingo.io import InputArgs
+
+input_data = {
+    "input_path": "../../test/data/test_local_jsonl.jsonl",  # local filesystem dataset
+    "save_data": True,
+    "save_correct": True,
+    "dataset": "local",
+    "data_format": "jsonl",
+    "column_content": "content",
+    "custom_config":
+        {
+            "prompt_list": ["PromptRepeat"],
+            "llm_config":
+                {
+                    "detect_text_quality":
+                        {
+                            "key": "enter your key, such as:EMPTY",
+                            "api_url": "enter your local llm api url, such as:http://127.0.0.1:8080/v1",
+                        }
+                }
+        },
+    "log_level": "INFO"
+}
+input_args = InputArgs(**input_data)
+executor = Executor.exec_map["local"](input_args)
+result = executor.execute()
+print(result)

--- a/examples/llm/remote_llm.py
+++ b/examples/llm/remote_llm.py
@@ -1,0 +1,29 @@
+from dingo.exec import Executor
+from dingo.io import InputArgs
+
+input_data = {
+    "input_path": "../../test/data/test_local_jsonl.jsonl",  # local filesystem dataset
+    "save_data": True,
+    "save_correct": True,
+    "dataset": "local",
+    "data_format": "jsonl",
+    "column_content": "content",
+    "custom_config":
+        {
+            "prompt_list": ["PromptRepeat"],
+            "llm_config":
+                {
+                    "detect_text_quality":
+                        {
+                            "model": "enter your llm, such as:deepseek-chat",
+                            "key": "enter your key, such as:sk-123456789012345678901234567890xx",
+                            "api_url": "enter remote llm api url, such as:https://api.deepseek.com/v1",
+                        }
+                }
+        },
+    "log_level": "INFO"
+}
+input_args = InputArgs(**input_data)
+executor = Executor.exec_map["local"](input_args)
+result = executor.execute()
+print(result)


### PR DESCRIPTION
I found that there is a lack of tutorial on using LLM in the project examples, so I added information on how to use it to call local and remote models.
In addition, the space example of HF also lacks the model attribute, which has been supplemented this time.
