### PR TITLE
feat: use repr() to explain the meaning of char.

### DIFF
--- a/dingo/model/rule/rule_common.py
+++ b/dingo/model/rule/rule_common.py
@@ -650,7 +650,7 @@ class RuleInvisibleChar(BaseRule):
             res.error_status = True
             res.type = cls.metric_type
             res.name = cls.__name__
-            res.reason = list(set(matches))
+            res.reason = [repr(s) for s in list(set(matches))]
         return res
 
 


### PR DESCRIPTION
When I use `RuleInvisibleChar`, I find the reason always print blank instead of the code of char. So I use the repr() to explain the meaning of char.